### PR TITLE
fix: Datadog build failure

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -476,8 +476,16 @@
     };
   };
 
-  services.datadog-agent = {
+nixpkgs.overlays = [
+    (final: prev: {
+      pythonPackages = prev.python311Packages; 
+    }
+    )
+  ];  
+
+services.datadog-agent = {
     enable = true;
+    package = (pkgs.datadog-agent.override {pythonPackages = pkgs.python311Packages;}); # https://github.com/NixOS/nixpkgs/issues/418555
     apiKeyFile = config.sops.secrets."datadog-agent/apiKey".path;
     site = "us5.datadoghq.com";
     extraConfig = {


### PR DESCRIPTION
Congela o python do datadog pra 3.12 enquanto o nixpkgs não arrumar

(fiz no celular, preciso testar ainda, WIP)