### PR TITLE
Mirror termux repos

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -415,6 +415,22 @@
     restartIfChanged = false;
   };
 
+  systemd.services.sync-termux-packages = {
+    script = ''
+      rsync -rlptH --safe-links --delete-delay --delay-updates --timeout=600 --contimeout=60 --no-motd --quiet rsync://packages.termux.dev/termux /data/mirror/termux
+    '';
+    path = [
+      pkgs.rsync
+    ];
+    startAt = "hourly";
+    serviceConfig = {
+      Type = "oneshot";
+      User = config.users.users.rsync.name;
+      Group = config.users.users.rsync.group;
+    };
+    restartIfChanged = false;
+  };
+
   systemd.settings.Manager.DefaultLimitNOFILE = 8192;
   services.nginx =
     let


### PR DESCRIPTION
I just started using termux and saw that there is no mirror on South America[1]. I just copied the rsync sync-mint-packages command and changed the url[2] and dest dir.

[1]: https://github.com/termux/termux-packages/wiki/Mirrors#mirrors
[2]: https://github.com/termux/termux-packages/wiki/How-to-mirror-the-official-repositories#mirroring-with-rsync